### PR TITLE
Replace useAxios with useQuery in the MyResourcesTable and props from all related components

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -91,7 +91,8 @@ export const URLs = {
     attachments: {
       get: '/attachments',
       patch: '/attachments/:id',
-      delete: '/attachments',
+      delete: '/attachments/:id',
+      deleteOld: '/attachments',
       post: '/attachments'
     },
     questions: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -85,7 +85,6 @@ export const URLs = {
       add: '/lessons',
       get: '/lessons',
       getById: '/lessons/:id',
-      deleteOld: '/lessons',
       delete: '/lessons/:id',
       patch: '/lessons/:id'
     },
@@ -93,7 +92,6 @@ export const URLs = {
       get: '/attachments',
       patch: '/attachments/:id',
       delete: '/attachments/:id',
-      deleteOld: '/attachments',
       post: '/attachments'
     },
     questions: {
@@ -108,7 +106,6 @@ export const URLs = {
       getNames: '/resources-categories/names',
       patch: '/resources-categories',
       post: '/resources-categories',
-      deleteOld: 'resources-categories',
       delete: 'resources-categories/:id'
     }
   },
@@ -123,7 +120,6 @@ export const URLs = {
     getById: '/quizzes/:id',
     add: '/quizzes',
     patch: '/quizzes/:id',
-    deleteOld: '/quizzes',
     delete: '/quizzes/:id'
   },
   finishedQuizzes: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -99,7 +99,7 @@ export const URLs = {
     questions: {
       get: '/questions',
       getById: '/questions/:id',
-      delete: '/questions',
+      delete: '/questions/:id',
       post: '/questions',
       patch: '/questions/:id'
     },

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -85,7 +85,8 @@ export const URLs = {
       add: '/lessons',
       get: '/lessons',
       getById: '/lessons/:id',
-      delete: '/lessons',
+      deleteOld: '/lessons',
+      delete: '/lessons/:id',
       patch: '/lessons/:id'
     },
     attachments: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -106,7 +106,7 @@ export const URLs = {
       getNames: '/resources-categories/names',
       patch: '/resources-categories',
       post: '/resources-categories',
-      delete: 'resources-categories/:id'
+      delete: '/resources-categories/:id'
     }
   },
   messages: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -108,7 +108,8 @@ export const URLs = {
       getNames: '/resources-categories/names',
       patch: '/resources-categories',
       post: '/resources-categories',
-      delete: 'resources-categories'
+      deleteOld: 'resources-categories',
+      delete: 'resources-categories/:id'
     }
   },
   messages: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -122,7 +122,8 @@ export const URLs = {
     getById: '/quizzes/:id',
     add: '/quizzes',
     patch: '/quizzes/:id',
-    delete: '/quizzes'
+    deleteOld: '/quizzes',
+    delete: '/quizzes/:id'
   },
   finishedQuizzes: {
     add: '/finished-quizzes',

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -140,25 +140,41 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
     [sectionData, resourceEventHandler]
   )
 
-  const deleteResource = (resource: CourseResource) => {
-    if (resource.isDuplicate) {
-      if (resource.resourceType === ResourcesTypesEnum.Lesson) {
-        void ResourceService.deleteLesson(resource._id)
-      }
+  const { mutate: handleDeleteResource } = useMutation<
+    void,
+    Error,
+    { resourceId: string; resource: CourseResource }
+  >({
+    mutationFn: async ({ resourceId, resource }) => {
+      switch (resource.resourceType) {
+        case ResourcesTypesEnum.Lesson: {
+          return ResourceService.deleteLesson(resourceId)
+        }
 
-      if (resource.resourceType === ResourcesTypesEnum.Quiz) {
-        void ResourceService.deleteQuiz(resource._id)
-      }
+        case ResourcesTypesEnum.Quiz: {
+          return ResourceService.deleteQuiz(resourceId)
+        }
 
-      if (resource.resourceType === ResourcesTypesEnum.Attachment) {
-        void ResourceService.deleteAttachment(resource._id)
+        case ResourcesTypesEnum.Attachment: {
+          return ResourceService.deleteAttachment(resourceId)
+        }
       }
+    },
+    onSuccess: (_data, variables) => {
+      const { resource } = variables
+
+      resourceEventHandler?.({
+        type: CourseResourceEventType.ResourceRemoved,
+        sectionId: sectionData.id,
+        resourceId: resource.id!
+      })
     }
-    resourceEventHandler?.({
-      type: CourseResourceEventType.ResourceRemoved,
-      sectionId: sectionData.id,
-      resourceId: resource.id!
-    })
+  })
+
+  const deleteResource = (resource: CourseResource) => {
+    if (resource.isDuplicate && resource._id) {
+      handleDeleteResource({ resourceId: resource._id, resource })
+    }
   }
 
   const { mutate: mutateAttachment } = useMutation({

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -159,22 +159,19 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
           return ResourceService.deleteAttachment(resourceId)
         }
       }
-    },
-    onSuccess: (_data, variables) => {
-      const { resource } = variables
-
-      resourceEventHandler?.({
-        type: CourseResourceEventType.ResourceRemoved,
-        sectionId: sectionData.id,
-        resourceId: resource.id!
-      })
     }
   })
 
   const deleteResource = (resource: CourseResource) => {
-    if (resource.isDuplicate && resource._id) {
+    if (resource.isDuplicate) {
       handleDeleteResource({ resourceId: resource._id, resource })
     }
+
+    resourceEventHandler?.({
+      type: CourseResourceEventType.ResourceRemoved,
+      sectionId: sectionData.id,
+      resourceId: resource.id!
+    })
   }
 
   const { mutate: mutateAttachment } = useMutation({

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -62,7 +62,7 @@ const QuizzesContainer = () => {
   }, [itemsPerPage, sort, searchTitle, page, selectedItems])
 
   const { mutate: handleDeleteQuiz } = useMutation({
-    mutationFn: ResourceService.deleteQuizQuery,
+    mutationFn: ResourceService.deleteQuiz,
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -28,6 +28,8 @@ import { type Quiz, ResourcesTabsEnum } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 import { getFullUrl } from '~/utils/get-full-url'
 import ChangeResourceConfirmModal from '../change-resource-confirm-modal/ChangeResourceConfirmModal'
+import useMutation from '~/hooks/use-mutation'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 const QuizzesContainer = () => {
   const navigate = useNavigate()
@@ -39,6 +41,7 @@ const QuizzesContainer = () => {
   const breakpoints = useBreakpoints()
   const [selectedItems, setSelectedItems] = useState<string[]>([])
   const { openModal } = useModalContext()
+  const { handleSuccessAlert, handleErrorAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -58,14 +61,15 @@ const QuizzesContainer = () => {
     })
   }, [itemsPerPage, sort, searchTitle, page, selectedItems])
 
-  const deleteQuiz = useCallback(
-    async (id?: string): Promise<AxiosResponse<unknown>> => {
-      const response = await ResourceService.deleteQuiz(id ?? '')
-      await queryClient.invalidateQueries({ queryKey: ['quizzes'] })
-      return response
-    },
-    [queryClient]
-  )
+  const { mutate: handleDeleteQuiz } = useMutation({
+    mutationFn: ResourceService.deleteQuizQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)
+      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when <N> issue will be merged
+    }
+    // queryKey: ['quizzes']
+  })
 
   const {
     data: quizzes,
@@ -112,14 +116,10 @@ const QuizzesContainer = () => {
 
   const props = {
     columns: columnsToShow,
-    data: {
-      response: quizzes ?? defaultResponses.itemsWithCount,
-      getData: getQuizzes
-    },
-    services: { deleteService: deleteQuiz },
+    resourceItems: quizzes ?? defaultResponses.itemsWithCount,
     itemsPerPage,
-    actions: { onEdit },
-    resource: ResourcesTabsEnum.Quizzes,
+    actions: { onEdit, onDelete: handleDeleteQuiz },
+    resourceType: ResourcesTabsEnum.Quizzes,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage }
   }

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useQueryClient } from '@tanstack/react-query'
 import Box from '@mui/material/Box'
-import { AxiosResponse } from 'axios'
 
 import { ResourceService } from '~/services/resource-service'
 import AddResourceWithInput from '~/containers/my-resources/add-resource-with-input/AddResourceWithInput'
@@ -11,7 +9,6 @@ import Loader from '~/components/loader/Loader'
 import useSort from '~/hooks/table/use-sort'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import useQuery from '~/hooks/use-query'
-import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 import usePagination from '~/hooks/table/use-pagination'
 import { authRoutes } from '~/router/constants/authRoutes'
 import { useModalContext } from '~/context/modal-context'
@@ -34,8 +31,6 @@ import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 const QuizzesContainer = () => {
   const navigate = useNavigate()
   const { page, handleChangePage } = usePagination()
-  const { handleErrorAlert } = useSnackbarAlert()
-  const queryClient = useQueryClient()
   const sortOptions = useSort({ initialSort })
   const searchTitle = useRef('')
   const breakpoints = useBreakpoints()
@@ -66,9 +61,8 @@ const QuizzesContainer = () => {
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)
-      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when 3183 issue will be merged
-    }
-    // queryKey: ['quizzes']
+    },
+    queryKey: ['quizzes']
   })
 
   const {

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -66,7 +66,7 @@ const QuizzesContainer = () => {
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)
-      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when <N> issue will be merged
+      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when 3183 issue will be merged
     }
     // queryKey: ['quizzes']
   })

--- a/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
+++ b/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
@@ -3,7 +3,6 @@ import {
   useEffect,
   useState,
   useRef,
-  type ComponentRef,
   type ChangeEvent
 } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -67,9 +66,9 @@ const CreateOrEditQuizContainer: React.FC<QuizContentProps> = ({
   const { id = '' } = useParams()
   const { handleErrorAlert, handleAlert } = useSnackbarAlert()
   const [isCreationOpen, setIsCreationOpen] = useState<boolean>(false)
-  const modalRef = useRef<ComponentRef<typeof CreateOrEditQuizQuestion> | null>(
-    null
-  )
+  const modalRef = useRef<{
+    openCreateModal: () => void
+  } | null>(null)
 
   const onCategoryChange = (
     _: React.SyntheticEvent,

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -90,7 +90,7 @@ const AttachmentsContainer: React.FC = () => {
   })
 
   const { mutate: handleCreateAttachment } = useMutation({
-    mutationFn: ResourceService.createAttachments,
+    mutationFn: ResourceService.createAttachment,
     onError: handleErrorAlert,
     queryKey: ['attachments']
   })

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -140,14 +140,10 @@ const AttachmentsContainer: React.FC = () => {
 
   const props = {
     columns: columnsToShow,
-    data: {
-      response: loadedAttachments ?? defaultResponses.itemsWithCount,
-      getData: invalidateAttachments
-    },
-    services: { deleteService: handleDeleteAttachment },
+    resourceItems: loadedAttachments,
     itemsPerPage,
-    actions: { onEdit},
-    resource: ResourcesTabsEnum.Attachments,
+    actions: { onEdit, onDelete: handleDeleteAttachment },
+    resourceType: ResourcesTabsEnum.Attachments,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage },
     sx: styles.table

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -14,7 +14,6 @@ import useBreakpoints from '~/hooks/use-breakpoints'
 import usePagination from '~/hooks/table/use-pagination'
 import AddDocuments from '~/containers/add-documents/AddDocuments'
 
-import { defaultResponses } from '~/constants'
 import {
   columns,
   initialSort,
@@ -29,6 +28,7 @@ import useMutation from '~/hooks/use-mutation'
 import useQuery from '~/hooks/use-query'
 import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 import { queryClient } from '~/plugins/queryClient'
+import { defaultResponses } from '~/constants'
 
 const AttachmentsContainer: React.FC = () => {
   const { t } = useTranslation()
@@ -59,7 +59,9 @@ const AttachmentsContainer: React.FC = () => {
   const { mutate: handleDeleteAttachment } = useMutation({
     mutationFn: ResourceService.deleteAttachment,
     onError: handleErrorAlert,
-    onSuccess: () => { handleSuccessAlert(`myResourcesPage.attachments.successDeletion`)},
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.attachments.successDeletion`)
+    },
     queryKey: ['attachments']
   })
 
@@ -140,7 +142,7 @@ const AttachmentsContainer: React.FC = () => {
 
   const props = {
     columns: columnsToShow,
-    resourceItems: loadedAttachments,
+    resourceItems: loadedAttachments ?? defaultResponses.itemsWithCount,
     itemsPerPage,
     actions: { onEdit, onDelete: handleDeleteAttachment },
     resourceType: ResourcesTabsEnum.Attachments,

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -57,7 +57,7 @@ const AttachmentsContainer: React.FC = () => {
   )
 
   const { mutate: handleDeleteAttachment } = useMutation({
-    mutationFn: ResourceService.deleteAttachmentQuery,
+    mutationFn: ResourceService.deleteAttachment,
     onError: handleErrorAlert,
     onSuccess: () => { handleSuccessAlert(`myResourcesPage.attachments.successDeletion`)},
     queryKey: ['attachments']

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -39,7 +39,7 @@ const AttachmentsContainer: React.FC = () => {
   const searchFileName = useRef<string>('')
   const [selectedItems, setSelectedItems] = useState<string[]>([])
   const formData = new FormData()
-  const { handleErrorAlert } = useSnackbarAlert()
+  const { handleSuccessAlert, handleErrorAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -56,10 +56,12 @@ const AttachmentsContainer: React.FC = () => {
     [itemsPerPage, page, sort, searchFileName, selectedItems]
   )
 
-  const deleteAttachment = useCallback(
-    (id?: string) => ResourceService.deleteAttachment(id ?? ''),
-    []
-  )
+  const { mutate: handleDeleteAttachment } = useMutation({
+    mutationFn: ResourceService.deleteAttachmentQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => { handleSuccessAlert(`myResourcesPage.attachments.successDeletion`)},
+    queryKey: ['attachments']
+  })
 
   const {
     data: loadedAttachments,
@@ -86,7 +88,7 @@ const AttachmentsContainer: React.FC = () => {
   })
 
   const { mutate: handleCreateAttachment } = useMutation({
-    mutationFn: ResourceService.createAttachment,
+    mutationFn: ResourceService.createAttachments,
     onError: handleErrorAlert,
     queryKey: ['attachments']
   })
@@ -142,9 +144,9 @@ const AttachmentsContainer: React.FC = () => {
       response: loadedAttachments ?? defaultResponses.itemsWithCount,
       getData: invalidateAttachments
     },
-    services: { deleteService: deleteAttachment },
+    services: { deleteService: handleDeleteAttachment },
     itemsPerPage,
-    actions: { onEdit },
+    actions: { onEdit},
     resource: ResourcesTabsEnum.Attachments,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage },

--- a/src/containers/my-resources/categories-container/CategoriesContainer.tsx
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.tsx
@@ -110,7 +110,7 @@ const CategoriesContainer = () => {
   })
 
   const { mutate: handleDeleteCategory } = useMutation({
-    mutationFn: ResourceService.deleteResourceCategoryQuery,
+    mutationFn: ResourceService.deleteResourceCategory,
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.categories.successDeletion`)

--- a/src/containers/my-resources/categories-container/CategoriesContainer.tsx
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.tsx
@@ -45,9 +45,9 @@ const CategoriesContainer = () => {
   const { openModal, closeModal } = useModalContext()
   const [selectedItemId, setSelectedItemId] = useState<string>('')
   const [updateResourceCategory] = useUpdateResourceCategoryMutation()
-  const { handleErrorAlert } = useSnackbarAlert()
   const queryClient = useQueryClient()
   const dispatch = useAppDispatch()
+  const { handleSuccessAlert, handleErrorAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -109,6 +109,15 @@ const CategoriesContainer = () => {
     queryFn: ResourceService.getResourcesCategoriesNames
   })
 
+  const { mutate: handleDeleteCategory } = useMutation({
+    mutationFn: ResourceService.deleteResourceCategoryQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.categories.successDeletion`)
+    },
+    queryKey: ['resource-categories']
+  })
+
   const { mutate: handleCreateCategory } = useMutation({
     mutationFn: ResourceService.createResourceCategory,
     onError: handleErrorAlert,
@@ -151,7 +160,7 @@ const CategoriesContainer = () => {
   )
 
   const props = {
-    actions: { onEdit },
+    actions: { onEdit, onDelete: handleDeleteCategory },
     columns: columnsToShow,
     data: {
       response: categories ?? defaultResponses.itemsWithCount,
@@ -161,7 +170,7 @@ const CategoriesContainer = () => {
     pagination: { page, onChange: handleChangePage },
     sort: sortOptions,
     itemsPerPage,
-    resource: ResourcesTabsEnum.Categories,
+    resourceType: ResourcesTabsEnum.Categories,
     sx: styles.table
   }
 

--- a/src/containers/my-resources/categories-container/CategoriesContainer.tsx
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.tsx
@@ -61,11 +61,6 @@ const CategoriesContainer = () => {
     })
   }, [page, itemsPerPage, sort, searchTitle])
 
-  const deleteCategory = useCallback(
-    (id?: string) => ResourceService.deleteResourceCategory(id ?? ''),
-    []
-  )
-
   const {
     error,
     data: categories,
@@ -162,11 +157,7 @@ const CategoriesContainer = () => {
   const props = {
     actions: { onEdit, onDelete: handleDeleteCategory },
     columns: columnsToShow,
-    data: {
-      response: categories ?? defaultResponses.itemsWithCount,
-      getData: updateInfo
-    },
-    services: { deleteService: deleteCategory },
+    resourceItems: categories ?? defaultResponses.itemsWithCount,
     pagination: { page, onChange: handleChangePage },
     sort: sortOptions,
     itemsPerPage,

--- a/src/containers/my-resources/categories-container/CategoriesContainer.tsx
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.tsx
@@ -110,7 +110,7 @@ const CategoriesContainer = () => {
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.categories.successDeletion`)
     },
-    queryKey: ['resource-categories']
+    queryKey: ['categories']
   })
 
   const { mutate: handleCreateCategory } = useMutation({

--- a/src/containers/my-resources/lessons-container/LessonsContainer.tsx
+++ b/src/containers/my-resources/lessons-container/LessonsContainer.tsx
@@ -126,11 +126,7 @@ const LessonsContainer = () => {
 
   const props = {
     columns: columnsToShow,
-    data: {
-      response: lessons ?? defaultResponses.itemsWithCount,
-      getData: handleInvalidateLessons
-    },
-    services: { deleteService: handleDeleteLesson },
+    resourceItems: lessons ?? defaultResponses.itemsWithCount,
     itemsPerPage,
     actions: { onEdit, onDelete: handleDeleteLesson },
     resourceType: ResourcesTabsEnum.Lessons,

--- a/src/containers/my-resources/lessons-container/LessonsContainer.tsx
+++ b/src/containers/my-resources/lessons-container/LessonsContainer.tsx
@@ -58,7 +58,7 @@ const LessonsContainer = () => {
   }, [page, itemsPerPage, sort, searchTitle, selectedItems])
 
   const { mutate: handleDeleteLesson } = useMutation({
-    mutationFn: ResourceService.deleteLessonQuery,
+    mutationFn: ResourceService.deleteLesson,
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.lessons.successDeletion`)

--- a/src/containers/my-resources/lessons-container/LessonsContainer.tsx
+++ b/src/containers/my-resources/lessons-container/LessonsContainer.tsx
@@ -26,6 +26,7 @@ import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 import { useModalContext } from '~/context/modal-context'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 import { getFullUrl } from '~/utils/get-full-url'
+import useMutation from '~/hooks/use-mutation'
 
 const LessonsContainer = () => {
   const navigate = useNavigate()
@@ -35,8 +36,8 @@ const LessonsContainer = () => {
   const searchTitle = useRef<string>('')
   const breakpoints = useBreakpoints()
   const [selectedItems, setSelectedItems] = useState<string[]>([])
-  const { handleErrorAlert } = useSnackbarAlert()
   const queryClient = useQueryClient()
+  const { handleErrorAlert, handleSuccessAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -56,10 +57,14 @@ const LessonsContainer = () => {
     })
   }, [page, itemsPerPage, sort, searchTitle, selectedItems])
 
-  const deleteLesson = useCallback(
-    (id?: string) => ResourceService.deleteLesson(id ?? ''),
-    []
-  )
+  const { mutate: handleDeleteLesson } = useMutation({
+    mutationFn: ResourceService.deleteLessonQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.lessons.successDeletion`)
+    },
+    queryKey: ['lessons']
+  })
 
   const {
     data: lessons,
@@ -125,10 +130,10 @@ const LessonsContainer = () => {
       response: lessons ?? defaultResponses.itemsWithCount,
       getData: handleInvalidateLessons
     },
-    services: { deleteService: deleteLesson },
+    services: { deleteService: handleDeleteLesson },
     itemsPerPage,
-    actions: { onEdit },
-    resource: ResourcesTabsEnum.Lessons,
+    actions: { onEdit, onDelete: handleDeleteLesson },
+    resourceType: ResourcesTabsEnum.Lessons,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage }
   }

--- a/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
+++ b/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
@@ -9,9 +9,9 @@ import EnhancedTable, {
 } from '~/components/enhanced-table/EnhancedTable'
 
 import {
-  TableItem,
-  ResourcesTableData,
-  TableRowAction,
+  type TableItem,
+  type TableRowAction,
+  type ItemsWithCount,
   ResourcesTabsEnum
 } from '~/types'
 import { roundedBorderTable } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
@@ -19,9 +19,9 @@ import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-mod
 
 interface MyResourcesTableInterface<T>
   extends Omit<EnhancedTableProps<T, undefined>, 'data'> {
-  resource: ResourcesTabsEnum
+  resourceType: ResourcesTabsEnum
   itemsPerPage: number
-  data: ResourcesTableData<T>
+  resourceItems: ItemsWithCount<T>
   actions: {
     onEdit: (id: string) => void
     onDuplicate?: (id: string) => void
@@ -31,9 +31,9 @@ interface MyResourcesTableInterface<T>
 }
 
 const MyResourcesTable = <T extends TableItem>({
-  resource,
+  resourceType,
   itemsPerPage,
-  data,
+  resourceItems,
   actions,
   pagination,
   ...props
@@ -43,24 +43,22 @@ const MyResourcesTable = <T extends TableItem>({
   const { openModal } = useModalContext()
 
   const { page, onChange } = pagination
-  const { response } = data
   const { onEdit, onDuplicate, onDelete } = actions
 
   const handleDelete = (id: string, isConfirmed: boolean) => {
-    console.log('id', id)
     if (isConfirmed) {
       onDelete(id)
     }
   }
 
   const handleConfirmDelete = (id: string) => {
-    const currentResource = response.items.find((item) => item._id === id)
+    const currentResource = resourceItems.items.find((item) => item._id === id)
 
     const handleConfirm = () => {
       openDialog({
         message: 'myResourcesPage.confirmDeletionMessage',
         sendConfirm: (isConfirmed: boolean) => handleDelete(id, isConfirmed),
-        title: `myResourcesPage.${resource}.confirmDeletionTitle`
+        title: `myResourcesPage.${resourceType}.confirmDeletionTitle`
       })
     }
 
@@ -78,7 +76,7 @@ const MyResourcesTable = <T extends TableItem>({
   const rowActions: TableRowAction[] = [
     {
       label:
-        resource === ResourcesTabsEnum.Categories
+        resourceType === ResourcesTabsEnum.Categories
           ? t('common.rename')
           : t('common.edit'),
       func: onEdit
@@ -96,8 +94,8 @@ const MyResourcesTable = <T extends TableItem>({
   return (
     <>
       <EnhancedTable<T>
-        data={{ items: response.items }}
-        emptyTableKey={`myResourcesPage.${resource}.emptyItems`}
+        data={{ items: resourceItems.items }}
+        emptyTableKey={`myResourcesPage.${resourceType}.emptyItems`}
         rowActions={rowActions}
         sx={roundedBorderTable}
         {...props}
@@ -105,7 +103,7 @@ const MyResourcesTable = <T extends TableItem>({
       <AppPagination
         onChange={onChange}
         page={page}
-        pageCount={Math.ceil(response.count / itemsPerPage)}
+        pageCount={Math.ceil(resourceItems.count / itemsPerPage)}
       />
     </>
   )

--- a/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
+++ b/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
@@ -1,9 +1,6 @@
 import { useTranslation } from 'react-i18next'
-import { AxiosResponse } from 'axios'
 import { PaginationProps } from '@mui/material'
 
-import { useAppDispatch } from '~/hooks/use-redux'
-import useAxios from '~/hooks/use-axios'
 import useConfirm from '~/hooks/use-confirm'
 import { useModalContext } from '~/context/modal-context'
 import AppPagination from '~/components/app-pagination/AppPagination'
@@ -11,9 +8,7 @@ import EnhancedTable, {
   EnhancedTableProps
 } from '~/components/enhanced-table/EnhancedTable'
 
-import { snackbarVariants } from '~/constants'
 import {
-  ErrorResponse,
   TableItem,
   ResourcesTableData,
   TableRowAction,
@@ -21,8 +16,6 @@ import {
 } from '~/types'
 import { roundedBorderTable } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
-import { openAlert } from '~/redux/features/snackbarSlice'
-import { getErrorKey } from '~/utils/get-error-key'
 
 interface MyResourcesTableInterface<T>
   extends Omit<EnhancedTableProps<T, undefined>, 'data'> {
@@ -32,8 +25,8 @@ interface MyResourcesTableInterface<T>
   actions: {
     onEdit: (id: string) => void
     onDuplicate?: (id: string) => void
+    onDelete: (id: string) => void
   }
-  services: { deleteService: (id?: string) => Promise<AxiosResponse> }
   pagination: PaginationProps
 }
 
@@ -42,60 +35,31 @@ const MyResourcesTable = <T extends TableItem>({
   itemsPerPage,
   data,
   actions,
-  services,
   pagination,
   ...props
 }: MyResourcesTableInterface<T>) => {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const { openDialog } = useConfirm()
   const { openModal } = useModalContext()
 
   const { page, onChange } = pagination
-  const { response, getData } = data
-  const { onEdit, onDuplicate } = actions
+  const { response } = data
+  const { onEdit, onDuplicate, onDelete } = actions
 
-  const onDeleteError = (error?: ErrorResponse) => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.error,
-        message: getErrorKey(error)
-      })
-    )
-  }
-
-  const onDeleteResponse = () => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.success,
-        message: `myResourcesPage.${resource}.successDeletion`
-      })
-    )
-  }
-
-  const { error, fetchData: deleteItem } = useAxios({
-    service: services.deleteService,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponseError: onDeleteError,
-    onResponse: onDeleteResponse
-  })
-
-  const handleDelete = async (id: string, isConfirmed: boolean) => {
+  const handleDelete = (id: string, isConfirmed: boolean) => {
+    console.log('id', id)
     if (isConfirmed) {
-      await deleteItem(id)
-      if (!error) await getData()
+      onDelete(id)
     }
   }
 
-  const onDelete = (id: string) => {
+  const handleConfirmDelete = (id: string) => {
     const currentResource = response.items.find((item) => item._id === id)
 
     const handleConfirm = () => {
       openDialog({
         message: 'myResourcesPage.confirmDeletionMessage',
-        sendConfirm: (isConfirmed: boolean) =>
-          void handleDelete(id, isConfirmed),
+        sendConfirm: (isConfirmed: boolean) => handleDelete(id, isConfirmed),
         title: `myResourcesPage.${resource}.confirmDeletionTitle`
       })
     }
@@ -121,7 +85,7 @@ const MyResourcesTable = <T extends TableItem>({
     },
     {
       label: t('common.delete'),
-      func: onDelete
+      func: handleConfirmDelete
     },
     onDuplicate && {
       label: t('common.duplicate'),

--- a/src/containers/my-resources/questions-container/QuestionsContainer.tsx
+++ b/src/containers/my-resources/questions-container/QuestionsContainer.tsx
@@ -92,7 +92,9 @@ const QuestionsContainer: React.FC = () => {
         return
       }
 
-      const item = questions.items.find((element) => element._id === id)
+      const item = questions?.items?.find(
+        (element: Question) => element._id === id
+      )
 
       if (!item) {
         handleErrorAlert(DuplicateQuestionErrors.QUESTION_NOT_FOUND)

--- a/src/containers/my-resources/questions-container/QuestionsContainer.tsx
+++ b/src/containers/my-resources/questions-container/QuestionsContainer.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useQueryClient } from '@tanstack/react-query'
 import Box from '@mui/material/Box'
-import type { AxiosResponse } from 'axios'
 
 import { ResourceService } from '~/services/resource-service'
 import AddResourceWithInput from '~/containers/my-resources/add-resource-with-input/AddResourceWithInput'
@@ -24,19 +22,19 @@ import {
   removeColumnRules,
   DuplicateQuestionErrors
 } from '~/containers/my-resources/questions-container/QuestionsContainer.constants'
-import { ResourcesTabsEnum, type Question } from '~/types'
 import { getFullUrl } from '~/utils/get-full-url'
+import { ResourcesTabsEnum, type Question } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 
 const QuestionsContainer: React.FC = () => {
   const sortOptions = useSort({ initialSort })
   const searchTitle = useRef('')
   const breakpoints = useBreakpoints()
-  const queryClient = useQueryClient()
-  const { handleAlert, handleErrorAlert } = useSnackbarAlert()
   const navigate = useNavigate()
   const { page, handleChangePage } = usePagination()
   const [selectedItems, setSelectedItems] = useState<string[]>([])
+  const { handleAlert, handleErrorAlert, handleSuccessAlert } =
+    useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -69,14 +67,15 @@ const QuestionsContainer: React.FC = () => {
     }
   })
 
-  const deleteQuestion = useCallback(
-    async (id?: string): Promise<AxiosResponse<unknown>> => {
-      const response = await ResourceService.deleteQuestion(id ?? '')
-      await queryClient.invalidateQueries({ queryKey: ['questions'] })
-      return response
-    },
-    [queryClient]
-  )
+  const { mutate: handleDeleteQuestion } = useMutation({
+    mutationFn: ResourceService.deleteQuestion,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.questions.successDeletion`)
+      void refetchQuestions() // TODO: remove and replace with queryKey, when 3184 issue will be merged
+    }
+    // queryKey: ['questions']
+  })
 
   const editQuestion = (id: string) => {
     navigate(
@@ -134,19 +133,14 @@ const QuestionsContainer: React.FC = () => {
 
   const props = {
     columns: columnsToShow,
-    data: {
-      response: questions ?? defaultResponses.itemsWithCount,
-      getData: getQuestions
-    },
-    services: {
-      deleteService: deleteQuestion
-    },
+    resourceItems: questions ?? defaultResponses.itemsWithCount,
     itemsPerPage,
     actions: {
       onEdit: editQuestion,
-      onDuplicate: duplicateItem
+      onDuplicate: duplicateItem,
+      onDelete: handleDeleteQuestion
     },
-    resource: ResourcesTabsEnum.Questions,
+    resourceType: ResourcesTabsEnum.Questions,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage }
   }

--- a/src/containers/my-resources/questions-container/QuestionsContainer.tsx
+++ b/src/containers/my-resources/questions-container/QuestionsContainer.tsx
@@ -72,9 +72,8 @@ const QuestionsContainer: React.FC = () => {
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.questions.successDeletion`)
-      void refetchQuestions() // TODO: remove and replace with queryKey, when 3184 issue will be merged
-    }
-    // queryKey: ['questions']
+    },
+    queryKey: ['questions']
   })
 
   const editQuestion = (id: string) => {

--- a/src/hooks/use-snackbar-alert.tsx
+++ b/src/hooks/use-snackbar-alert.tsx
@@ -46,7 +46,18 @@ const useSnackbarAlert = () => {
     },
     [handleAlert]
   )
-  return { handleAlert, handleErrorAlert }
+
+  const handleSuccessAlert = useCallback(
+    (message: string) => {
+      handleAlert({
+        message,
+        severity: snackbarVariants.success
+      })
+    },
+    [handleAlert]
+  )
+
+  return { handleAlert, handleErrorAlert, handleSuccessAlert }
 }
 
 export default useSnackbarAlert

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -202,12 +202,7 @@ export const ResourceService = {
       })
     })
   },
-  getQuestions: (
-    params?: GetResourcesParams
-  ): Promise<AxiosResponse<ItemsWithCount<Question>>> => {
-    return axiosClient.get(URLs.resources.questions.get, { params })
-  },
-  getQuestionsQuery: (params?: GetResourcesParams) => {
+  getQuestions: (params?: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Question>>({
       method: 'GET',
       url: getFullUrl({
@@ -216,7 +211,6 @@ export const ResourceService = {
       })
     })
   },
-
   getQuestion: (id: string) => {
     return baseService.request<GetQuestion>({
       method: 'GET',
@@ -226,7 +220,6 @@ export const ResourceService = {
       })
     })
   },
-
   createQuestion: (data: CreateQuestionData) => {
     return baseService.request<Question>({
       method: 'POST',
@@ -234,7 +227,6 @@ export const ResourceService = {
       data
     })
   },
-
   updateQuestion: (data: UpdateQuestionParams) => {
     const { id, ...questionData } = data
 
@@ -256,10 +248,14 @@ export const ResourceService = {
       })
     })
   },
-  getResourcesCategories: (
-    params?: GetResourcesCategoriesParams
-  ): Promise<AxiosResponse<ItemsWithCount<Categories>>> => {
-    return axiosClient.get(URLs.resources.resourcesCategories.get, { params })
+  getResourcesCategories: (params?: GetResourcesCategoriesParams) => {
+    return baseService.request<ItemsWithCount<Categories>>({
+      method: 'GET',
+      url: getFullUrl({
+        pathname: URLs.resources.resourcesCategories.get,
+        searchParameters: params
+      })
+    })
   },
   getResourcesCategoriesNames: () => {
     return baseService.request<CategoryNameInterface[]>({

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -174,20 +174,31 @@ export const ResourceService = {
       data: attachmentData
     })
   },
-  deleteAttachment: async (id: string): Promise<AxiosResponse> => {
-    return await axiosClient.delete(
-      createUrlPath(URLs.resources.attachments.delete, id)
-    )
-  },
-  createAttachment: (data: FormData) => {
-    return baseService.request<Attachment>({
-      method: 'POST',
-      url: URLs.resources.attachments.post,
-      data
+  createAttachments: (data?: FormData): Promise<AxiosResponse> => {
+    return axiosClient.post(URLs.attachments.post, data, {
+      headers: { 'Content-Type': 'multipart/form-data' }
     })
   },
-
-  getQuestions: (params?: GetResourcesParams) => {
+  deleteAttachment: async (id: string): Promise<AxiosResponse> => {
+    return await axiosClient.delete(
+      createUrlPath(URLs.resources.attachments.deleteOld, id)
+    )
+  },
+  deleteAttachmentQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.resources.attachments.delete,
+        parameters: { id }
+      })
+    })
+  },
+  getQuestions: (
+    params?: GetResourcesParams
+  ): Promise<AxiosResponse<ItemsWithCount<Question>>> => {
+    return axiosClient.get(URLs.resources.questions.get, { params })
+  },
+  getQuestionsQuery: (params?: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Question>>({
       method: 'GET',
       url: getFullUrl({

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -128,7 +128,16 @@ export const ResourceService = {
     })
   },
   deleteQuiz: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(createUrlPath(URLs.quizzes.delete, id)),
+    await axiosClient.delete(createUrlPath(URLs.quizzes.deleteOld, id)),
+  deleteQuizQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.quizzes.delete,
+        parameters: { id }
+      })
+    })
+  },
   addFinishedQuiz: async (data: CreateFinishedQuizParams) => {
     return baseService.request<FinishedQuiz>({
       method: 'POST',

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -56,11 +56,7 @@ export const ResourceService = {
       })
     })
   },
-  deleteLesson: async (id: string): Promise<AxiosResponse<Lesson>> =>
-    await axiosClient.delete(
-      createUrlPath(URLs.resources.lessons.deleteOld, id)
-    ),
-  deleteLessonQuery: (id: string) => {
+  deleteLesson: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({
@@ -127,9 +123,7 @@ export const ResourceService = {
       data: quizData
     })
   },
-  deleteQuiz: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(createUrlPath(URLs.quizzes.deleteOld, id)),
-  deleteQuizQuery: (id: string) => {
+  deleteQuiz: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({
@@ -199,12 +193,7 @@ export const ResourceService = {
       headers: { 'Content-Type': 'multipart/form-data' }
     })
   },
-  deleteAttachment: async (id: string): Promise<AxiosResponse> => {
-    return await axiosClient.delete(
-      createUrlPath(URLs.resources.attachments.deleteOld, id)
-    )
-  },
-  deleteAttachmentQuery: (id: string) => {
+  deleteAttachment: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({
@@ -285,11 +274,7 @@ export const ResourceService = {
       data: params
     })
   },
-  deleteResourceCategory: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(
-      createUrlPath(URLs.resources.resourcesCategories.deleteOld, id)
-    ),
-  deleteResourceCategoryQuery: (id: string) => {
+  deleteResourceCategory: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -57,7 +57,18 @@ export const ResourceService = {
     })
   },
   deleteLesson: async (id: string): Promise<AxiosResponse<Lesson>> =>
-    await axiosClient.delete(createUrlPath(URLs.resources.lessons.delete, id)),
+    await axiosClient.delete(
+      createUrlPath(URLs.resources.lessons.deleteOld, id)
+    ),
+  deleteLessonQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.resources.lessons.delete,
+        parameters: { id }
+      })
+    })
+  },
   addLesson: async (data: LessonData) => {
     return baseService.request<Lesson & { category: string | null }>({
       method: 'POST',

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -258,19 +258,19 @@ export const ResourceService = {
       data: questionData
     })
   },
-
-  deleteQuestion: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(
-      createUrlPath(URLs.resources.questions.delete, id)
-    ),
-  getResourcesCategories: (params: GetResourcesCategoriesParams) => {
-    return baseService.request<ItemsWithCount<Categories>>({
-      method: 'GET',
+  deleteQuestion: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
       url: getFullUrl({
-        pathname: URLs.resources.resourcesCategories.get,
-        searchParameters: params
+        pathname: URLs.resources.questions.delete,
+        parameters: { id }
       })
     })
+  },
+  getResourcesCategories: (
+    params?: GetResourcesCategoriesParams
+  ): Promise<AxiosResponse<ItemsWithCount<Categories>>> => {
+    return axiosClient.get(URLs.resources.resourcesCategories.get, { params })
   },
   getResourcesCategoriesNames: () => {
     return baseService.request<CategoryNameInterface[]>({

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -287,8 +287,17 @@ export const ResourceService = {
   },
   deleteResourceCategory: async (id: string): Promise<AxiosResponse> =>
     await axiosClient.delete(
-      createUrlPath(URLs.resources.resourcesCategories.delete, id)
-    )
+      createUrlPath(URLs.resources.resourcesCategories.deleteOld, id)
+    ),
+  deleteResourceCategoryQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.resources.resourcesCategories.delete,
+        parameters: { id }
+      })
+    })
+  }
 }
 
 export const resourceService = appApi.injectEndpoints({

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -188,7 +188,7 @@ export const ResourceService = {
       data: attachmentData
     })
   },
-  createAttachments: (data?: FormData): Promise<AxiosResponse> => {
+  createAttachment: (data?: FormData): Promise<AxiosResponse> => {
     return axiosClient.post(URLs.attachments.post, data, {
       headers: { 'Content-Type': 'multipart/form-data' }
     })

--- a/src/types/my-resources/myResources.index.ts
+++ b/src/types/my-resources/myResources.index.ts
@@ -1,3 +1,2 @@
 export * from '~/types/my-resources/interfaces/myResources.interface'
-export * from '~/types/my-resources/types/myResources.types'
 export * from '~/types/my-resources/enum/myResources.enum'

--- a/src/types/my-resources/types/myResources.types.ts
+++ b/src/types/my-resources/types/myResources.types.ts
@@ -1,5 +1,0 @@
-import { ItemsWithCount } from '~/types'
-
-export type ResourcesTableData<T> = {
-  response: ItemsWithCount<T>
-}

--- a/src/types/my-resources/types/myResources.types.ts
+++ b/src/types/my-resources/types/myResources.types.ts
@@ -1,8 +1,5 @@
-import { ItemsWithCount, GetResourcesParams } from '~/types'
+import { ItemsWithCount } from '~/types'
 
 export type ResourcesTableData<T> = {
   response: ItemsWithCount<T>
-  getData: (
-    params?: GetResourcesParams
-  ) => Promise<void> | void | Promise<ItemsWithCount<T>>
 }

--- a/tests/unit/containers/my-resources/MyResourcesTable.spec.jsx
+++ b/tests/unit/containers/my-resources/MyResourcesTable.spec.jsx
@@ -47,17 +47,14 @@ const responseItemsMock = Array(10)
   }))
 
 const props = {
-  resource: 'lessons',
+  resourceType: 'lessons',
   pagination: {
     page: 1,
     onChange: vi.fn()
   },
-  data: {
-    response: {
-      items: responseItemsMock,
-      count: 10
-    },
-    getData: vi.fn()
+  resourceItems: {
+    items: responseItemsMock,
+    count: 10
   },
   actions: {
     onEdit: vi.fn(),

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -338,4 +338,18 @@ describe('resourseService tests', () => {
     )
     expect(result).toEqual(mockQuestionData)
   })
+
+  it('should delete an attachment', async () => {
+    const attachmentId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.resources.attachments.delete.replace(':id', attachmentId))
+      .reply(200)
+
+    await ResourceService.deleteAttachment(attachmentId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.attachments.delete.replace(':id', attachmentId)
+    )
+  })
 })

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -28,6 +28,20 @@ describe('resourseService tests', () => {
     )
   })
 
+  it('should delete a lesson', async () => {
+    const lessonId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.resources.lessons.delete.replace(':id', lessonId))
+      .reply(200)
+
+    await ResourceService.deleteLesson(lessonId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.lessons.delete.replace(':id', lessonId)
+    )
+  })
+
   it('should fetch a quiz by ID', async () => {
     const quizId = '6641388f36ebdb0432a3a2e5'
     const mockQuizData = {
@@ -127,6 +141,20 @@ describe('resourseService tests', () => {
     expect(createdQuiz).toEqual(mockResponse)
   })
 
+  it('should delete a quiz', async () => {
+    const quizId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.quizzes.delete.replace(':id', quizId))
+      .reply(200)
+
+    await ResourceService.deleteQuiz(quizId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.quizzes.delete.replace(':id', quizId)
+    )
+  })
+  
   it('should get resource categories names', async () => {
     const mockResponse = [
       { _id: '1', name: 'Category 1' },
@@ -162,6 +190,20 @@ describe('resourseService tests', () => {
     expect(response).toEqual(mockResponse)
   })
 
+  it('should delete a resource category', async () => {
+    const resourceCategoryId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.resources.resourcesCategories.delete.replace(':id', resourceCategoryId))
+      .reply(200)
+
+    await ResourceService.deleteResourceCategory(resourceCategoryId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.resourcesCategories.delete.replace(':id', resourceCategoryId)
+    )
+  })
+
   it('should edit an attachment', async () => {
     const attachmentId = '6255bc080a75adf9223df444'
     const attachment = {
@@ -176,14 +218,17 @@ describe('resourseService tests', () => {
       resourceType: 'Attachment'
     }
 
-    mockAxiosClient
-      .onPatch(URLs.resources.attachments.patch.replace(':id', attachmentId))
-      .reply(200, mockAttachmentResponse)
+    mockAxiosClient.onPatch().reply((config) => {
+      expect(config.url).toBe(`/attachments/${attachmentId}`)
 
-    const updatedAttachmentResponse = await ResourceService.updateAttachment({
-      ...attachment,
-      id: attachmentId
+      return [200, mockAttachmentResponse]
     })
+
+    const updatedAttachmentResponse =
+      await ResourceService.updateAttachmentQuery({
+        ...attachment,
+        id: attachmentId
+      })
 
     expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
   })
@@ -350,6 +395,20 @@ describe('resourseService tests', () => {
 
     expect(mockAxiosClient.history.delete[0].url).toBe(
       URLs.resources.attachments.delete.replace(':id', attachmentId)
+    )
+  })
+
+  it('should delete a question', async () => {
+    const questionId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.resources.questions.delete.replace(':id', questionId))
+      .reply(200)
+
+    await ResourceService.deleteQuestion(questionId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.questions.delete.replace(':id', questionId)
     )
   })
 })

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -154,7 +154,7 @@ describe('resourseService tests', () => {
       URLs.quizzes.delete.replace(':id', quizId)
     )
   })
-  
+
   it('should get resource categories names', async () => {
     const mockResponse = [
       { _id: '1', name: 'Category 1' },
@@ -194,13 +194,21 @@ describe('resourseService tests', () => {
     const resourceCategoryId = '6255bc080a75adf9223df444'
 
     mockAxiosClient
-      .onDelete(URLs.resources.resourcesCategories.delete.replace(':id', resourceCategoryId))
+      .onDelete(
+        URLs.resources.resourcesCategories.delete.replace(
+          ':id',
+          resourceCategoryId
+        )
+      )
       .reply(200)
 
     await ResourceService.deleteResourceCategory(resourceCategoryId)
 
     expect(mockAxiosClient.history.delete[0].url).toBe(
-      URLs.resources.resourcesCategories.delete.replace(':id', resourceCategoryId)
+      URLs.resources.resourcesCategories.delete.replace(
+        ':id',
+        resourceCategoryId
+      )
     )
   })
 
@@ -224,11 +232,10 @@ describe('resourseService tests', () => {
       return [200, mockAttachmentResponse]
     })
 
-    const updatedAttachmentResponse =
-      await ResourceService.updateAttachmentQuery({
-        ...attachment,
-        id: attachmentId
-      })
+    const updatedAttachmentResponse = await ResourceService.updateAttachment({
+      ...attachment,
+      id: attachmentId
+    })
 
     expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
   })
@@ -310,7 +317,7 @@ describe('resourseService tests', () => {
 
     const response = await ResourceService.createAttachment(attachment)
 
-    expect(response).toEqual(mockAttachmentResponse)
+    expect(response.data).toEqual(mockAttachmentResponse)
   })
 
   it('should update a question', async () => {


### PR DESCRIPTION
Notes: Do after containers useAxios --> useQuery  PR's

- Refactor MyResourcesTable component props
- Replace delete methods passed as props to MyResourcesTable with useMutation delete mutation
- Repalce delete<name>Query to delete<name> in resource-service. 
- Ensure that replaced delete<name> work correctly in other components that use methods
- Fix tests

Correct work of delete demo:

https://github.com/user-attachments/assets/1b8b4709-8ba9-4e4e-8fbd-bedfcc74e046

MyResourcesTable can be found in {{baseFrontendUrl}}/my-resources:

![image](https://github.com/user-attachments/assets/7584ba52-8f9c-45ad-8f00-8aebb41ff58a)
