### PR TITLE
Fix isDuplicate resources id is not refetched from server

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -92,7 +92,8 @@ export const URLs = {
       get: '/attachments',
       patch: '/attachments/:id',
       delete: '/attachments/:id',
-      post: '/attachments'
+      post: '/attachments',
+      duplicate: '/attachments/duplicate/:id'
     },
     questions: {
       get: '/questions',

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -252,7 +252,9 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
     resources: T[],
     isDuplicate: boolean
   ) => {
-    const newResources: (Lesson | Quiz)[] = []
+    const newResources: (Lesson | Quiz | Attachment)[] = []
+    console.log('newResources', newResources, 'isDuplicate', isDuplicate)
+
     if (isDuplicate) {
       for (const resource of resources) {
         if (resource.resourceType === ResourcesTypesEnum.Lesson) {
@@ -268,18 +270,30 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
           })
 
           newResources.push(newLesson)
-        } else if (resource.resourceType === ResourcesTypesEnum.Quiz) {
+        }
+
+        if (resource.resourceType === ResourcesTypesEnum.Quiz) {
           const quiz = resource as Quiz
+
           const newQuiz = await ResourceService.addQuiz({
             title: quiz.title,
             description: quiz.description,
             items: quiz.items,
             isDuplicate: isDuplicate,
             resourceType: ResourcesTypesEnum.Quiz,
-            category: null,
-            id: crypto.randomUUID()
+            category: null
           })
+
           newResources.push(newQuiz)
+        }
+
+        if (resource.resourceType === ResourcesTypesEnum.Attachment) {
+          const attachment = resource as Attachment
+          const newAttachment = await ResourceService.duplicateAttachment(
+            attachment._id
+          )
+
+          newResources.push(newAttachment)
         }
       }
     }

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -193,6 +193,15 @@ export const ResourceService = {
       headers: { 'Content-Type': 'multipart/form-data' }
     })
   },
+  duplicateAttachment: (id: string) => {
+    return baseService.request<Attachment>({
+      method: 'POST',
+      url: getFullUrl({
+        pathname: URLs.resources.attachments.duplicate,
+        parameters: { id }
+      })
+    })
+  },
   deleteAttachment: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',


### PR DESCRIPTION
## Before:

Without data refetching, invalid original resource is removed instead of isDuplicate:

https://github.com/user-attachments/assets/90bdb93e-4701-41ec-83ea-7ed212917004

With data refatching, everythink works as expected:

https://github.com/user-attachments/assets/eb255fa1-c5f8-4ac0-a0b6-f6a24066ef39


## After:

https://github.com/user-attachments/assets/1d2deea7-776c-4328-8601-4f2ff2f926a9


